### PR TITLE
Upgrade grpcio version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+grpcio==1.44.0rc2
 google-auth==1.24.0
 google-cloud-firestore==2.0.2
 pyzmq==21.0.1


### PR DESCRIPTION
I'm not sure if this is gonna be needed, as grpcio package will be automatically upgraded when the new version is released, since the dependency is defined as <2.0dev and >=1.29.0.

v1.44.0 is officially released (https://github.com/grpc/grpc/releases/tag/v1.44.0), so this should be ready soon.